### PR TITLE
chore(deps): bump react and react-dom together to 19.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "bufferutil": "^4.1.0",
         "next": "^16.2.7",
         "porto": "~0.2.35",
-        "react": "^19.2.6",
+        "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-hot-toast": "^2.6.0",
         "react-markdown": "^10.1.0",
@@ -17538,9 +17538,9 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@metamask/connect-evm": "^1.4.0",
     "bufferutil": "^4.1.0",
     "next": "^16.2.7",
-    "react": "^19.2.6",
+    "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-hot-toast": "^2.6.0",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary
- Dependabot PR #336 bumped only `react-dom` to 19.2.7, leaving `react` at 19.2.6. React enforces that these packages share an exact version, so every component test suite failed in CI with "Incompatible React versions".
- Bumps both `react` and `react-dom` to `^19.2.7` (both now published on npm) so they stay in lockstep.

## Test plan
- [x] `npm test` passes locally in the project's Docker container (17/17 suites, 214/214 tests)
- [x] Pre-commit/pre-push hooks (typecheck, lint, format, jest) pass

Closes / supersedes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)