### PR TITLE
fix: exclude .claude/ from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,6 +38,9 @@ yarn-error.log*
 *.swo
 *~
 
+# Claude Code worktrees (can contain stale node_modules/symlinks)
+.claude
+
 # CI
 .github
 


### PR DESCRIPTION
## Summary
- `npm run precheck:docker` was failing with `invalid file request .claude/worktrees/.../node_modules/.bin/acorn` because a stale Claude Code worktree under `.claude/worktrees/` ships a `node_modules` tree with symlinks Docker can't include in the build context.
- `.claude/` is already gitignored but wasn't dockerignored, ballooning the build context to >1GB and aborting the build.
- Adds `.claude` to `.dockerignore`, bringing the build context back to normal and `precheck:docker` back to a clean pass.

## Test plan
- [x] `npm run precheck:docker` — 4 passed (9.8s), 16 skipped (local-only tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)