### PR TITLE
Refresh portfolio positioning, reorder featured projects, add SkyView client

### DIFF
--- a/src/app/_components/HeroSection.module.css
+++ b/src/app/_components/HeroSection.module.css
@@ -196,6 +196,17 @@
   user-select: none;
 }
 
+.landingCompanies {
+  font-size: clamp(0.85rem, 1.1vw, 0.95rem);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: rgba(148, 163, 184, 0.9);
+  margin: 0.75rem 0 0;
+  text-shadow: 0 2px 10px rgba(2, 6, 23, 0.85);
+  -webkit-user-select: none;
+  user-select: none;
+}
+
 .landingCTA {
   display: flex;
   gap: 1.25rem;

--- a/src/app/_components/LandingHero.tsx
+++ b/src/app/_components/LandingHero.tsx
@@ -15,15 +15,18 @@ export const LandingHero: React.FC = () => {
         <h1 className={styles.landingTitle}>
           Austin J. Hardy
           <br />
-          Senior Systems Engineer
-          <br />
-          <span className={styles.highlight}>SaaS | AI | Web3</span>
+          <span className={styles.highlight}>
+            Senior Platform & AI Engineer
+          </span>
         </h1>
 
         <p className={styles.landingDescription}>
-          I build intelligent systems that translate human intent into AI
-          execution. Currently working on multi-agent orchestration, repository
-          intelligence, and blockchain applications.
+          15 years building enterprise tooling, Atlassian platforms, and
+          AI-powered systems that engineers actually want to use.
+        </p>
+
+        <p className={styles.landingCompanies}>
+          Netflix &middot; Coinbase &middot; Blackboard
         </p>
       </div>
     </section>

--- a/src/app/_components/_styles/FeaturedProjects.css
+++ b/src/app/_components/_styles/FeaturedProjects.css
@@ -139,10 +139,6 @@
   margin-bottom: 0.5rem;
   font-size: 0.82rem;
   flex-grow: 1;
-  display: -webkit-box;
-  -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 .featured-project-card .project-tags {
@@ -277,10 +273,6 @@
   background: #9a3412;
   transform: translateY(-2px);
   box-shadow: var(--shadow-md);
-}
-
-.featured-project-card--other-projects .project-description {
-  -webkit-line-clamp: 3;
 }
 
 .featured-header .label-ai {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,11 +12,11 @@ import { Providers } from "./providers";
 import "./test-helpers.css";
 
 export const metadata: Metadata = {
-  title: "Austin J. Hardy | Developer & Researcher | nitsuah.io",
+  title: "Austin J. Hardy | Senior Platform & AI Engineer | nitsuah.io",
   description:
-    "Personal portfolio showcasing cryptography research, enterprise automation tools, and Web3 experiments. Austin J. Hardy's selected projects and technical work.",
+    "Senior Platform & AI Engineer — 15 years building Atlassian enterprise platforms, MCP servers, and AI-powered developer tooling at Netflix, Coinbase, and Blackboard.",
   keywords:
-    "Austin Hardy, nitsuah, developer, cryptography, Web3, Python, Next.js, portfolio, blockchain, automation",
+    "Austin Hardy, nitsuah, platform engineer, AI engineer, Atlassian, MCP, Next.js, TypeScript, enterprise automation, Web3",
   authors: [{ name: "Austin J. Hardy", url: "https://nitsuah.io" }],
   creator: "Austin J. Hardy",
   publisher: "Austin J. Hardy",
@@ -29,23 +29,23 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: "https://nitsuah.io",
     siteName: "nitsuah.io",
-    title: "Austin J. Hardy | Developer & Researcher",
+    title: "Austin J. Hardy | Senior Platform & AI Engineer",
     description:
-      "Personal portfolio showcasing cryptography research, enterprise automation tools, and Web3 experiments.",
+      "15 years building Atlassian enterprise platforms, MCP servers, and AI-powered developer tooling at Netflix, Coinbase, and Blackboard.",
     images: [
       {
         url: "/social-preview.svg", // TODO: Convert to PNG for better social media compatibility
         width: 1200,
         height: 630,
-        alt: "Austin J. Hardy - Developer & Researcher Portfolio",
+        alt: "Austin J. Hardy - Senior Platform & AI Engineer Portfolio",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Austin J. Hardy | Developer & Researcher",
+    title: "Austin J. Hardy | Senior Platform & AI Engineer",
     description:
-      "Personal portfolio showcasing cryptography research, enterprise automation tools, and Web3 experiments.",
+      "15 years building Atlassian enterprise platforms, MCP servers, and AI-powered developer tooling at Netflix, Coinbase, and Blackboard.",
     images: ["/social-preview.svg"], // TODO: Convert to PNG for better compatibility
     creator: "@nitsuah",
   },

--- a/src/app/projects/_styles/Projects.module.css
+++ b/src/app/projects/_styles/Projects.module.css
@@ -458,4 +458,13 @@
     text-align: center;
     padding: 0.75rem 1rem;
   }
+
+  .tagButtons {
+    gap: 0.4rem;
+  }
+
+  .tagButton {
+    padding: 0.3rem 0.65rem;
+    font-size: 0.78rem;
+  }
 }

--- a/src/app/projects/clients/_comp/clients/ClientsProjectList.tsx
+++ b/src/app/projects/clients/_comp/clients/ClientsProjectList.tsx
@@ -17,6 +17,9 @@ type Project = {
   description: string;
   type: ProjectType;
   status: string;
+  technologies?: string[];
+  liveUrl?: string;
+  githubUrl?: string;
 };
 
 const ClientsProjectList: React.FC<{
@@ -75,7 +78,13 @@ const ClientsProjectList: React.FC<{
               flexDirection: "column",
               position: "relative",
             }}
-            onClick={() => setShowDemo(project.id)}
+            onClick={() => {
+              if (project.liveUrl) {
+                window.open(project.liveUrl, "_blank", "noopener,noreferrer");
+              } else {
+                setShowDemo(project.id);
+              }
+            }}
           >
             <div
               style={{
@@ -162,26 +171,91 @@ const ClientsProjectList: React.FC<{
               {project.description}
             </p>
 
-            <button
-              style={{
-                padding: "0.5rem 1rem",
-                background: "rgba(16, 185, 129, 0.2)",
-                border: "1px solid rgba(16, 185, 129, 0.4)",
-                borderRadius: "6px",
-                color: "#10b981",
-                fontWeight: "600",
-                fontSize: "0.875rem",
-                cursor: "pointer",
-                transition: "all 0.2s ease",
-                marginTop: "auto",
-              }}
-              onClick={(e) => {
-                e.stopPropagation();
-                setShowDemo(project.id);
-              }}
-            >
-              Launch Demo
-            </button>
+            {project.technologies && project.technologies.length > 0 && (
+              <p
+                style={{
+                  color: "rgba(16, 185, 129, 0.8)",
+                  fontSize: "0.75rem",
+                  textAlign: "center",
+                  margin: "0 0 0.75rem 0",
+                  fontWeight: "600",
+                }}
+              >
+                Stack: {project.technologies.join(" · ")}
+              </p>
+            )}
+
+            {project.liveUrl ? (
+              <div
+                style={{ display: "flex", gap: "0.5rem", marginTop: "auto" }}
+              >
+                <a
+                  href={project.liveUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={(e) => e.stopPropagation()}
+                  style={{
+                    flex: 1,
+                    padding: "0.5rem 1rem",
+                    background: "rgba(16, 185, 129, 0.2)",
+                    border: "1px solid rgba(16, 185, 129, 0.4)",
+                    borderRadius: "6px",
+                    color: "#10b981",
+                    fontWeight: "600",
+                    fontSize: "0.875rem",
+                    textAlign: "center",
+                    textDecoration: "none",
+                    transition: "all 0.2s ease",
+                  }}
+                >
+                  Live Site ↗
+                </a>
+                {project.githubUrl && (
+                  <a
+                    href={project.githubUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    style={{
+                      flex: 1,
+                      padding: "0.5rem 1rem",
+                      background: "rgba(255, 255, 255, 0.05)",
+                      border: "1px solid rgba(255, 255, 255, 0.2)",
+                      borderRadius: "6px",
+                      color: "rgba(255,255,255,0.8)",
+                      fontWeight: "600",
+                      fontSize: "0.875rem",
+                      textAlign: "center",
+                      textDecoration: "none",
+                      transition: "all 0.2s ease",
+                    }}
+                  >
+                    GitHub
+                  </a>
+                )}
+              </div>
+            ) : (
+              <button
+                style={{
+                  padding: "0.5rem 1rem",
+                  background: "rgba(16, 185, 129, 0.2)",
+                  border: "1px solid rgba(16, 185, 129, 0.4)",
+                  borderRadius: "6px",
+                  color: "#10b981",
+                  fontWeight: "600",
+                  fontSize: "0.875rem",
+                  cursor: "pointer",
+                  transition: "all 0.2s ease",
+                  marginTop: "auto",
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowDemo(project.id);
+                }}
+              >
+                Launch Demo
+              </button>
+            )}
           </div>
         ))}
       </div>

--- a/src/lib/data/client-projects.ts
+++ b/src/lib/data/client-projects.ts
@@ -16,9 +16,24 @@ export interface ClientProject {
   features: string[];
   status: "live" | "demo" | "mockup";
   icon?: string;
+  liveUrl?: string;
+  githubUrl?: string;
 }
 
 export const clientProjects: ClientProject[] = [
+  {
+    id: "skyview",
+    name: "SkyView Dynamics",
+    type: "service",
+    description:
+      "Cinematic drone services marketing site for a real client. Video hero, Decap CMS for content management, Calendly booking integration, Netlify Forms, and a Playwright E2E + Vitest test suite.",
+    technologies: ["JavaScript", "Netlify", "Playwright"],
+    features: ["Video Hero", "Decap CMS", "Calendly Booking", "Netlify Forms"],
+    status: "live",
+    icon: "🚁",
+    liveUrl: "https://skyview.nitsuah.io",
+    githubUrl: "https://github.com/nitsuah/skyview",
+  },
   {
     id: "storefront",
     name: "Storefront",

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -20,21 +20,6 @@ export type Project = {
 const projects: Project[] = [
   // Flagship Projects (Featured on Home Page)
   {
-    id: "agent-board",
-    title: "Agent Board",
-    short:
-      "Unified dashboard orchestrating autonomous AI agents across GitHub repositories.",
-    description:
-      "Local-first AI control room for multi-model workflows. Chat, safety rails, and live observability in one dashboard — no external APIs, no data leaving your machine.",
-    github: "https://github.com/nitsuah/agent-board",
-    highlight:
-      "Multi-agent orchestration, repo intelligence, automated governance",
-    tags: ["typescript", "nextjs", "ai", "devops"],
-    category: "Apps",
-    status: "active",
-    featured: true,
-  },
-  {
     id: "overseer",
     title: "Overseer",
     short:
@@ -50,38 +35,6 @@ const projects: Project[] = [
     status: "active",
     featured: true,
   },
-  {
-    id: "bb-mcp",
-    title: "Blackboard MCP",
-    short:
-      "Production-ready MCP server providing multi-persona access to Blackboard LMS data.",
-    description:
-      "Full-stack AI product engineering demonstration as an MCP server, exposing Blackboard LMS data across student, instructor, admin, and parent personas with RBAC, PII handling, rate limiting, and streaming response support.",
-    github: "https://github.com/nitsuah/bb-mcp",
-    highlight:
-      "Multi-persona tools, RBAC, streaming responses, institutional compliance",
-    tags: ["typescript", "mcp", "ai", "api"],
-    category: "Apps",
-    status: "active",
-    featured: false,
-  },
-  {
-    id: "darkmoon",
-    title: "darkmoon.dev",
-    short:
-      "Full-stack portfolio site with Web3 integrations, real-time blockchain data, and 3D graphics.",
-    description:
-      "Advanced portfolio website showcasing Web3 integration, real-time blockchain applications, 3D Spline animations, and modern React patterns. Serves as a secondary portfolio domain with specialized project content.",
-    github: "https://github.com/nitsuah/darkmoon",
-    externalLink: "https://darkmoon.dev",
-    infoUrl: "https://darkmoon.dev",
-    highlight: "Web3 integration, real-time data, 3D graphics, design showcase",
-    tags: ["typescript", "nextjs", "web3", "3d"],
-    category: "Web3",
-    status: "active",
-    featured: true,
-  },
-  // Original Projects
   {
     id: "kryptos",
     title: "Kryptos",
@@ -99,6 +52,69 @@ const projects: Project[] = [
     featured: true,
   },
   {
+    id: "darkmoon",
+    title: "darkmoon.dev",
+    short:
+      "Full-stack portfolio site with Web3 integrations, real-time blockchain data, and 3D graphics.",
+    description:
+      "Advanced portfolio website showcasing Web3 integration, real-time blockchain applications, 3D Spline animations, and modern React patterns. Serves as a secondary portfolio domain with specialized project content.",
+    github: "https://github.com/nitsuah/darkmoon",
+    externalLink: "https://darkmoon.dev",
+    infoUrl: "https://darkmoon.dev",
+    highlight: "Web3 integration, real-time data, 3D graphics, design showcase",
+    tags: ["typescript", "nextjs", "web3", "3d"],
+    category: "Web3",
+    status: "active",
+    featured: true,
+  },
+  {
+    id: "bb-mcp",
+    title: "Blackboard MCP",
+    short:
+      "Production-ready MCP server providing multi-persona access to Blackboard LMS data.",
+    description:
+      "Full-stack AI product engineering demonstration as an MCP server, exposing Blackboard LMS data across student, instructor, admin, and parent personas with RBAC, PII handling, rate limiting, and streaming response support.",
+    github: "https://github.com/nitsuah/bb-mcp",
+    highlight:
+      "Multi-persona tools, RBAC, streaming responses, institutional compliance",
+    tags: ["typescript", "mcp", "ai", "api"],
+    category: "Apps",
+    status: "active",
+    featured: true,
+  },
+  {
+    id: "stash",
+    title: "Stash",
+    short:
+      "15 years of enterprise automation: Atlassian, AWS IaC, SSO flows, and a role-based AI agent system.",
+    description:
+      "15 years of enterprise automation artifacts — Atlassian config templates, AWS IaC, OAuth/SAML/OIDC flows, SaaS API examples (Okta, Datadog, PagerDuty, Slack), and a role-based AI agent system for personal ops and product delivery.",
+    github: "https://github.com/nitsuah/stash",
+    demo: "",
+    highlight:
+      "Practical enterprise tooling, IT automation, workflow optimization",
+    tags: ["powershell", "vba", "devops", "sysadmin", "ai"],
+    category: "Apps",
+    status: "maintained",
+    featured: true,
+  },
+  // Additional Projects
+  {
+    id: "agent-board",
+    title: "Agent Board",
+    short:
+      "Unified dashboard orchestrating autonomous AI agents across GitHub repositories.",
+    description:
+      "Local-first AI control room for multi-model workflows. Chat, safety rails, and live observability in one dashboard — no external APIs, no data leaving your machine.",
+    github: "https://github.com/nitsuah/agent-board",
+    highlight:
+      "Multi-agent orchestration, repo intelligence, automated governance",
+    tags: ["typescript", "nextjs", "ai", "devops"],
+    category: "Apps",
+    status: "active",
+    featured: false,
+  },
+  {
     id: "gcp",
     title: "GCP Tools",
     short: "Google Drive reporting & migration scripts (Drive API automation).",
@@ -110,23 +126,7 @@ const projects: Project[] = [
     tags: ["python", "gcp", "automation", "enterprise"],
     category: "Apps",
     status: "maintained",
-    featured: true,
-  },
-  {
-    id: "stash",
-    title: "Stash",
-    short:
-      "Collection of sysadmin scripts (PowerShell, VBA, Atlassian helpers).",
-    description:
-      "Comprehensive system administration toolkit containing PowerShell automation scripts, VBA macros for Office integration, and Atlassian workflow helpers for enterprise IT operations.",
-    github: "https://github.com/nitsuah/stash",
-    demo: "",
-    highlight:
-      "Practical enterprise tooling, IT automation, workflow optimization",
-    tags: ["powershell", "vba", "devops", "sysadmin"],
-    category: "Apps",
-    status: "maintained",
-    featured: true,
+    featured: false,
   },
   {
     id: "nitsuah-io",

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -9,22 +9,22 @@ export function generatePersonSchema() {
     url: "https://nitsuah.io",
     image: "https://nitsuah.io/social-preview.png",
     sameAs: ["https://github.com/nitsuah", "https://github.com/Nitsuah-Labs"],
-    jobTitle: "Developer & Researcher",
+    jobTitle: "Senior Platform & AI Engineer",
     worksFor: {
       "@type": "Organization",
       name: "Nitsuah Labs",
     },
     knowsAbout: [
-      "Cryptography",
-      "Web3 Development",
-      "Python Programming",
+      "Atlassian Platform Engineering",
+      "AI Agents & MCP Servers",
       "Enterprise Automation",
       "Next.js",
       "TypeScript",
-      "System Administration",
+      "Cryptography",
+      "Web3 Development",
     ],
     description:
-      "Developer and researcher specializing in cryptography research, enterprise automation tools, and Web3 experiments.",
+      "Senior Platform & AI Engineer with 15 years building Atlassian enterprise platforms, MCP servers, and AI-powered developer tooling at Netflix, Coinbase, and Blackboard.",
     mainEntityOfPage: {
       "@type": "WebPage",
       "@id": "https://nitsuah.io",
@@ -56,7 +56,7 @@ export function generateWebSiteSchema() {
     alternateName: "nitsuah.io",
     url: "https://nitsuah.io",
     description:
-      "Personal portfolio showcasing cryptography research, enterprise automation tools, and Web3 experiments.",
+      "Senior Platform & AI Engineer — 15 years building Atlassian enterprise platforms, MCP servers, and AI-powered developer tooling at Netflix, Coinbase, and Blackboard.",
     author: {
       "@type": "Person",
       name: "Austin J. Hardy",


### PR DESCRIPTION
## Summary
- Repositioned hero/meta copy around platform & AI engineering (Netflix/Coinbase/Blackboard) on the homepage, layout metadata, and JSON-LD schema
- Reordered homepage featured projects so Overseer, Kryptos, darkmoon.dev, and Blackboard MCP lead (top 4 shown), and refreshed the Stash project description/tags
- Added the SkyView Dynamics client project (live site + GitHub links, tech stack) and a "Stack:" line on all client cards
- Removed `-webkit-line-clamp` truncation that was clipping featured project descriptions
- Tightened mobile filter tag-button sizing on `/projects`

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` (214 tests) passes via pre-commit/pre-push hooks
- [ ] CI checks green
- [ ] Spot-check homepage hero, `/projects` featured cards, and `/projects/clients` SkyView card in deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)