### PR TITLE
Fix home card stacking, resume background, and projects nav click

### DIFF
--- a/src/app/_components/_site/_comp/homebar/DesktopNav.tsx
+++ b/src/app/_components/_site/_comp/homebar/DesktopNav.tsx
@@ -1,10 +1,12 @@
 "use client";
 import Button from "@mui/material/Button";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import React from "react";
 import { navStyles, portfolioSub } from "../../homebarConfig";
 
 const DesktopNav: React.FC<{ pages: string[] }> = ({ pages }) => {
+  const router = useRouter();
   const [projectsOpen, setProjectsOpen] = React.useState(false);
   const [labsExpanded, setLabsExpanded] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
@@ -61,7 +63,12 @@ const DesktopNav: React.FC<{ pages: string[] }> = ({ pages }) => {
           aria-expanded={projectsOpen}
           aria-controls="projects-inline"
           onClick={() => {
-            setProjectsOpen((s) => !s);
+            if (projectsOpen) {
+              setProjectsOpen(false);
+              router.push("/projects");
+            } else {
+              setProjectsOpen(true);
+            }
           }}
           sx={{ color: (navStyles.link as any).color || undefined }}
         >

--- a/src/app/_components/_styles/FeaturedProjects.css
+++ b/src/app/_components/_styles/FeaturedProjects.css
@@ -57,7 +57,7 @@
   align-items: start;
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1025px) {
   .featured-projects-grid {
     align-items: stretch;
   }
@@ -313,7 +313,7 @@
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .featured-projects-section {
     height: auto;
     overflow: visible;

--- a/src/app/resume/resume.css
+++ b/src/app/resume/resume.css
@@ -38,7 +38,7 @@
   max-width: 850px;
   margin: 0 auto;
   padding: 5rem 1.5rem 2rem; /* Add top padding for fixed header */
-  background: #fff;
+  background: var(--color-background);
   font-family:
     -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
     Arial, sans-serif;
@@ -50,13 +50,12 @@
     color 0.3s ease;
 }
 .resume-page-root {
-  background: var(--color-surface);
+  background: var(--color-background);
   min-height: 100vh;
 }
 
 /* Dark Mode Support */
 :root.dark .resume-container {
-  background: #1a1a1a;
   color: #e0e0e0;
 }
 


### PR DESCRIPTION
## Summary
- Stack featured project cards vertically below 1024px viewport width so the home page grid no longer breaks/squishes at mid-range widths (e.g. half-screen between ~40-75%); scrolling is allowed in this stacked layout
- Resume page background now uses `var(--color-background)` (both the page root and container) so it matches the rest of the site in light and dark mode, instead of hardcoded `#fff` / `#1a1a1a`
- Desktop nav: clicking "Projects" while the submenu is already expanded now navigates to `/projects` instead of just collapsing the menu (matches mobile dropdown behavior)

## Test plan
- [x] `tsc --noEmit` passes
- [x] Unit test suite passes (214/214)
- [ ] Manually verify card stacking between 768px-1440px viewport widths
- [ ] Manually verify resume background matches site background in light/dark mode
- [ ] Manually verify clicking "Projects" twice on desktop nav navigates to /projects