### PR TITLE
fix(ci): fix flaky Playwright tests

### DIFF
--- a/config/Dockerfile.test
+++ b/config/Dockerfile.test
@@ -1,7 +1,7 @@
 # Dockerfile for running Playwright tests in a consistent environment
 # Uses production build to ensure all pages are pre-compiled
 
-FROM mcr.microsoft.com/playwright:v1.60.0-noble
+FROM mcr.microsoft.com/playwright:v1.61.1-noble
 
 # Set working directory
 WORKDIR /app

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -46,5 +46,5 @@ test("browser sanity check (local only)", async ({ page }) => {
     "Browser smoke runs locally only unless FORCE_BROWSER_E2E=1"
   );
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await expect(page.locator("html")).toBeVisible();
+  await expect(page.locator("body")).toBeVisible();
 });

--- a/tests/utils/wait-for-hydration.ts
+++ b/tests/utils/wait-for-hydration.ts
@@ -15,7 +15,7 @@ export async function waitForReactHydration(page: Page, timeout = 30000) {
     // timeout, the page failed to render and the calling test should fail.
     await page.waitForSelector("header, main, footer, #basics, .resume-container", {
       state: "attached",
-      timeout: 10000,
+      timeout: 30000,
     });
     return;
   }


### PR DESCRIPTION
Increase timeout for landmarks and update sanity check.

- Fix version mismatch in Dockerfile.
- Increase timeout for landmark checks in CI to prevent flakiness.
- Use body locator instead of html for sanity check.