### PR TITLE
fix(playwright): increase timeout and improve CI hydration check

### DIFF
--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -46,5 +46,5 @@ test("browser sanity check (local only)", async ({ page }) => {
     "Browser smoke runs locally only unless FORCE_BROWSER_E2E=1"
   );
   await page.goto("/", { waitUntil: "domcontentloaded" });
-  await expect(page.locator("body")).toBeVisible();
+  await expect(page.locator("body")).toBeVisible({ timeout: 60000 });
 });

--- a/tests/utils/wait-for-hydration.ts
+++ b/tests/utils/wait-for-hydration.ts
@@ -15,8 +15,32 @@ export async function waitForReactHydration(page: Page, timeout = 30000) {
     // timeout, the page failed to render and the calling test should fail.
     await page.waitForSelector("header, main, footer, #basics, .resume-container", {
       state: "attached",
-      timeout: 30000,
+      timeout: 60000,
     });
+
+    // Wait for React to hydrate - check that body has actual content
+    // We look for either #__next (Pages) or a main element (App) with content
+    await page.waitForFunction(
+      () => {
+        const main = document.querySelector("main");
+        const nextRoot = document.querySelector("#__next");
+        const body = document.body;
+
+        // Check that we have a significant number of children or content
+        const hasContent =
+          (main && main.childElementCount > 0) ||
+          (nextRoot && nextRoot.childElementCount > 0) ||
+          (body && body.childElementCount > 2);
+
+        // Also check that documentElement is not null
+        const hasDocument = document.documentElement !== null;
+
+        return !!(hasContent && hasDocument);
+      },
+      { timeout }
+    );
+
+    await page.waitForTimeout(1000);
     return;
   }
 


### PR DESCRIPTION
Addresses failing playwright-nightly tests by increasing timeouts and making the CI hydration check more robust in tests/utils/wait-for-hydration.ts and tests/smoke.spec.ts.

🤖 Generated with Claude Code