### PR TITLE
fix: bump @hono/node-server override to 2.0.12 (GHSA-wwfh-h76j-fc44, GHSA-9mqv-5hh9-4cgg)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1743,12 +1743,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "js-yaml": "4.3.0",
     "glob": "13.0.6",
     "axios": "1.18.1",
-    "@hono/node-server": "1.19.17",
+    "@hono/node-server": "2.0.12",
     "protobufjs": "7.6.5",
     "brace-expansion": "5.0.8",
     "next": {


### PR DESCRIPTION
## Summary

- Bumps `@hono/node-server` npm override from `1.19.17` -> `2.0.12`
- Patches two CVEs introduced via `accounts -> wata -> @hono/node-server`:
  - **GHSA-wwfh-h76j-fc44** - path traversal via `%5C` in `serve-static` (< 2.0.5)
  - **GHSA-9mqv-5hh9-4cgg** - WebSocket DoS via aborted handshake (2.0.0-2.0.9)

## Context

`wata` only imports `getRequestListener` from `@hono/node-server` - not `serve-static` - so neither CVE was reachable in practice. Production also runs on Netlify (Linux), and the path-traversal is Windows-only. Override bumped to clear Dependabot alert and resolve both advisories.

## Test plan

- [x] `npm audit` no longer flags `@hono/node-server`
- [x] Typecheck passes (`tsc --noEmit`)
- [x] All 214 unit tests pass (17 suites)

Closes #134

Generated with [Claude Code](https://claude.com/claude-code)