### PR TITLE
fix: bump hono to >=4.12.34 (ReDoS in CORS middleware)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12004,9 +12004,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "typescript-eslint": "^8.62.1"
   },
   "overrides": {
+    "hono": ">=4.12.34",
     "yaml": ">=1.10.3",
     "postcss": "8.5.25",
     "uuid": "11.1.1",


### PR DESCRIPTION
## Summary

- Adds `"hono": ">=4.12.34"` to the `overrides` block in `package.json` to force all transitive dependents (`accounts@0.15.5`, `porto@0.2.37`) onto the patched release
- Resolves [Dependabot alert #159](https://github.com/Nitsuah-Labs/nitsuah-io/security/dependabot?q=is%3Aopen+package%3Ahono) — hono CORS middleware ReDoS via `Access-Control-Request-Headers`
- `hono` in `package-lock.json` now resolves to `4.13.0` (above the patched floor of `4.12.34`)

## Test plan

- [x] `npm install --package-lock-only` completed cleanly inside Docker
- [x] `package-lock.json` confirms `node_modules/hono` resolves to `4.13.0`
- [x] All 214 Jest unit tests pass
- [ ] Verify Dependabot alert closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)